### PR TITLE
Don't have permission to write to default error path

### DIFF
--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -241,7 +241,7 @@ class NginxFull < Formula
       --http-uwsgi-temp-path=#{var}/run/nginx/uwsgi_temp
       --http-scgi-temp-path=#{var}/run/nginx/scgi_temp
       --http-log-path=#{var}/log/nginx/access.log
-      --error-log-path=#{var}/log/nginx/error.log
+      --error-log-path=stderr
     ]
 
     # Core Modules


### PR DESCRIPTION
Patch to make sure nginx doesn't fail when starting up since the default error log is pointing to a readonly path. Once nginx reads the config file during startup, the error path is set to a writable path.